### PR TITLE
Add purchase order PDF support

### DIFF
--- a/output/PurchaseOrder.json
+++ b/output/PurchaseOrder.json
@@ -1,0 +1,24 @@
+{
+  "metadata": {
+    "po_number": "PO123",
+    "po_date": "2024-06-01",
+    "buyer_name": "ABC Corp",
+    "vendor_name": "XYZ Supplies",
+    "currency": "USD",
+    "payment_terms": "Net 30",
+    "line_items": [
+      {
+        "item_number": "1",
+        "description": "Widget",
+        "quantity": 5.0,
+        "unit_price": 10.0,
+        "total_price": 50.0,
+        "uom": "pcs"
+      }
+    ],
+    "subtotal": 50.0,
+    "tax_amount": 5.0,
+    "shipping_fee": 2.0,
+    "grand_total": 57.0
+  }
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ langchain
 langchain-openai
 python-dotenv
 python-multipart
+fpdf

--- a/src/core/metadata_extractor.py
+++ b/src/core/metadata_extractor.py
@@ -1,10 +1,16 @@
 from typing import Union
 
-from llm.prompts import INVOICE_PROMPT, CONTRACT_PROMPT, EARNINGS_REPORT_PROMPT
+from llm.prompts import (
+    INVOICE_PROMPT,
+    CONTRACT_PROMPT,
+    EARNINGS_REPORT_PROMPT,
+    PURCHASE_ORDER_PROMPT,
+)
 from llm.utils import get_azure_chat_openai_llm, retry_on_rate_limit
 from models.metadata_models.contract import ContractMetadata
 from models.metadata_models.earnings_report import EarningsReportMetadata
 from models.metadata_models.invoice import InvoiceMetadata
+from models.metadata_models.purchase_order import PurchaseOrderMetadata
 
 
 class MetadataExtractor:
@@ -19,17 +25,23 @@ class MetadataExtractor:
             self.llm = get_azure_chat_openai_llm()
         else:
             self.llm = llm
-
         self.schemas = {
             "invoice": (InvoiceMetadata, INVOICE_PROMPT),
             "contract": (ContractMetadata, CONTRACT_PROMPT),
             "earnings_report": (EarningsReportMetadata, EARNINGS_REPORT_PROMPT),
+            "purchase_order": (PurchaseOrderMetadata, PURCHASE_ORDER_PROMPT),
         }
 
     @retry_on_rate_limit()
     def extract(
             self, doc_type: str, doc_text: str
-    ) -> Union[InvoiceMetadata, ContractMetadata, EarningsReportMetadata, dict]:
+    ) -> Union[
+        InvoiceMetadata,
+        ContractMetadata,
+        EarningsReportMetadata,
+        PurchaseOrderMetadata,
+        dict,
+    ]:
         """
         Extract structured metadata from a document based on its type.
 

--- a/src/llm/prompts.py
+++ b/src/llm/prompts.py
@@ -1,5 +1,5 @@
-CLASSIFY_PROMPT_TEMPLATE = """You are a document classifier for business documents. The possible document types are: 
-"invoice", "contract", or "earnings_report".
+CLASSIFY_PROMPT_TEMPLATE = """You are a document classifier for business documents. The possible document types are:
+"invoice", "contract", "earnings_report", or "purchase_order".
 
 You will be provided with the text from one of the following business documents:
 - invoice: A typical business invoice (there are 2 such files)
@@ -8,7 +8,7 @@ You will be provided with the text from one of the following business documents:
 
 Given the following document text, classify it and respond only with a valid JSON object matching this schema:
 {{
-  "type": "...",         // one of: "invoice", "contract", "earnings_report", "unknown"
+  "type": "...",         // one of: "invoice", "contract", "earnings_report", "purchase_order", "unknown"
   "confidence": ...      // number between 0 and 1
 }}
 
@@ -116,6 +116,26 @@ IMPORTANT GUIDELINES:
    - Do not include speculative analysis or information not present in the document
 
 Return ONLY a JSON matching the expected schema. All key_metrics keys must be in snake_case (lowercase with underscores).
+Document:
+\"\"\"{doc_text}\"\"\"
+"""
+
+
+PURCHASE_ORDER_PROMPT = """
+You are a purchase order document understanding assistant. Extract the following metadata from the purchase order text below:
+- po_number
+- po_date
+- buyer_name
+- vendor_name
+- currency
+- payment_terms
+- line_items: each with item_number, description, quantity, unit_price, total_price, uom
+- subtotal
+- tax_amount
+- shipping_fee
+- grand_total
+
+Return ONLY a JSON matching the expected schema.
 Document:
 \"\"\"{doc_text}\"\"\"
 """

--- a/src/models/document_classification.py
+++ b/src/models/document_classification.py
@@ -7,12 +7,15 @@ class DocumentType(str, Enum):
     invoice = "invoice"
     contract = "contract"
     earnings_report = "earnings_report"
+    purchase_order = "purchase_order"
     unknown = "unknown"
 
 
 class DocumentClassification(BaseModel):
     type: DocumentType = Field(
         ...,
-        description="Document type: invoice, contract, earnings_report, or unknown"
+        description=(
+            "Document type: invoice, contract, earnings_report, purchase_order, or unknown"
+        ),
     )
     confidence: float = Field(..., description="Confidence score between 0 and 1")

--- a/src/models/metadata_models/purchase_order.py
+++ b/src/models/metadata_models/purchase_order.py
@@ -1,0 +1,42 @@
+from typing import List, Optional
+from pydantic import BaseModel
+from models.metadata_models.base_metadata import BaseMetadata
+
+
+class PurchaseOrderLineItem(BaseModel):
+    item_number: Optional[str]
+    description: Optional[str]
+    quantity: Optional[float] = None
+    unit_price: Optional[float] = None
+    total_price: Optional[float] = None
+    uom: Optional[str] = None
+
+
+class PurchaseOrderMetadata(BaseMetadata):
+    po_number: Optional[str] = None
+    po_date: Optional[str] = None
+    buyer_name: Optional[str] = None
+    vendor_name: Optional[str] = None
+    currency: Optional[str] = None
+    payment_terms: Optional[str] = None
+    line_items: List[PurchaseOrderLineItem] = []
+    subtotal: Optional[float] = None
+    tax_amount: Optional[float] = None
+    shipping_fee: Optional[float] = None
+    grand_total: Optional[float] = None
+
+    def pretty_print(self):
+        print("📦 Purchase Order Metadata")
+        print(f"  🔢 PO Number: {self.po_number or 'N/A'}")
+        print(f"  📅 PO Date: {self.po_date or 'N/A'}")
+        print(f"  🛒 Buyer: {self.buyer_name or 'N/A'}")
+        print(f"  🏭 Vendor: {self.vendor_name or 'N/A'}")
+        print(f"  💱 Currency: {self.currency or 'N/A'}")
+        print(f"  💳 Payment Terms: {self.payment_terms or 'N/A'}")
+        print("  📦 Line Items:")
+        for i, item in enumerate(self.line_items, 1):
+            print(f"    {i}. {item.description or 'N/A'} - {item.quantity or '?'} {item.uom or ''} @ {item.unit_price or '?'} = {item.total_price or '?'}")
+        print(f"  Subtotal: {self.subtotal if self.subtotal is not None else 'N/A'}")
+        print(f"  Tax Amount: {self.tax_amount if self.tax_amount is not None else 'N/A'}")
+        print(f"  Shipping Fee: {self.shipping_fee if self.shipping_fee is not None else 'N/A'}")
+        print(f"  Grand Total: {self.grand_total if self.grand_total is not None else 'N/A'}")

--- a/tests/test_document_classifier.py
+++ b/tests/test_document_classifier.py
@@ -1,8 +1,11 @@
 import os
 import random
 
+import sys
 import pytest
 from sklearn.metrics import accuracy_score, precision_score, recall_score
+
+sys.path.append('src')
 
 from core.document_classifier import DocumentClassifier
 from core.document_ingestor import DocumentIngestor

--- a/tests/test_purchase_order_extractor.py
+++ b/tests/test_purchase_order_extractor.py
@@ -1,0 +1,83 @@
+from pathlib import Path
+import sys
+
+sys.path.append('src')
+
+from fpdf import FPDF
+
+from core.document_ingestor import DocumentIngestor
+from core.metadata_extractor import MetadataExtractor
+from models.metadata_models.purchase_order import (
+    PurchaseOrderMetadata,
+    PurchaseOrderLineItem,
+)
+
+
+class DummyLLM:
+    """Simple LLM stub that returns fixed purchase order metadata."""
+
+    def with_structured_output(self, schema):
+        class _Invoker:
+            def invoke(self, prompt):
+                return PurchaseOrderMetadata(
+                    po_number="PO123",
+                    po_date="2024-06-01",
+                    buyer_name="ABC Corp",
+                    vendor_name="XYZ Supplies",
+                    currency="USD",
+                    payment_terms="Net 30",
+                    line_items=[
+                        PurchaseOrderLineItem(
+                            item_number="1",
+                            description="Widget",
+                            quantity=5.0,
+                            unit_price=10.0,
+                            total_price=50.0,
+                            uom="pcs",
+                        )
+                    ],
+                    subtotal=50.0,
+                    tax_amount=5.0,
+                    shipping_fee=2.0,
+                    grand_total=57.0,
+                )
+
+        return _Invoker()
+
+
+def _create_sample_po_pdf(path: Path) -> Path:
+    pdf = FPDF()
+    pdf.add_page()
+    pdf.set_font("Helvetica", size=12)
+    pdf.cell(0, 10, "Purchase Order", ln=1)
+    pdf.cell(0, 10, "PO Number: PO123", ln=1)
+    pdf.cell(0, 10, "PO Date: 2024-06-01", ln=1)
+    pdf.cell(0, 10, "Buyer: ABC Corp", ln=1)
+    pdf.cell(0, 10, "Vendor: XYZ Supplies", ln=1)
+    pdf.cell(0, 10, "Currency: USD", ln=1)
+    pdf.cell(0, 10, "Payment Terms: Net 30", ln=1)
+    pdf.cell(0, 10, "Item Description Qty UOM Unit Price Total", ln=1)
+    pdf.cell(0, 10, "1 Widget 5 pcs 10.00 50.00", ln=1)
+    pdf.cell(0, 10, "Subtotal: 50.00", ln=1)
+    pdf.cell(0, 10, "Tax: 5.00", ln=1)
+    pdf.cell(0, 10, "Shipping: 2.00", ln=1)
+    pdf.cell(0, 10, "Grand Total: 57.00", ln=1)
+    output = path / "sample_po.pdf"
+    pdf.output(str(output))
+    return output
+
+
+def test_purchase_order_extraction(tmp_path):
+    pdf_path = _create_sample_po_pdf(tmp_path)
+    ingestor = DocumentIngestor(str(pdf_path))
+    text = ingestor.get_full_text()
+    extractor = MetadataExtractor(llm=DummyLLM())
+    metadata = extractor.extract("purchase_order", text)
+
+    assert metadata.po_number == "PO123"
+    assert metadata.buyer_name == "ABC Corp"
+    assert metadata.vendor_name == "XYZ Supplies"
+    assert metadata.currency == "USD"
+    assert metadata.payment_terms == "Net 30"
+    assert metadata.grand_total == 57.00
+    assert len(metadata.line_items) == 1


### PR DESCRIPTION
## Summary
- add purchase order prompt and wire into metadata extractor schema
- drop custom extractor to use the same LLM-based logic as other document types
- add stub-based unit test for purchase order PDFs

## Testing
- `pytest tests/test_purchase_order_extractor.py -q`
- `pytest -q` *(fails: FileNotFoundError for classifier test data)*

------
https://chatgpt.com/codex/tasks/task_e_68414f1904ec832b9c430eb52f9e2133