### PR TITLE
Update README for new retry helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ LLM providers like OpenAI enforce rate limits on API usage. If too many requests
 
 **Solution:**
 
-- Implement **exponential backoff with retries**, already built into the `with_retries()` in the `llm_utils.py` module. This progressively increases the wait time between retries.
+ - Implement **exponential backoff with retries**, available via the `retry_on_rate_limit()` function in `llm/utils.py`. This progressively increases the wait time between retries.
 - Provision multiple GPT-4o deployments (e.g., `gpt4o-east`, `gpt4o-west`) and cycle through them using a **round-robin mechanism** to balance load and avoid throttling on a single endpoint.
 
 ---


### PR DESCRIPTION
## Summary
- document the `retry_on_rate_limit()` helper in `llm/utils.py`

## Testing
- `pytest -q` *(fails: No module named 'sklearn')*

------
https://chatgpt.com/codex/tasks/task_e_6841795c7d30832bad4f4fee66e7fccd